### PR TITLE
feat: scaffold React + Vite frontend (closes #3)

### DIFF
--- a/demo/job-board/client/.gitignore
+++ b/demo/job-board/client/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/demo/job-board/client/index.html
+++ b/demo/job-board/client/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>JobBoard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/demo/job-board/client/package.json
+++ b/demo/job-board/client/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "job-board-client",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.2.55",
+    "@types/react-dom": "^18.2.19",
+    "@vitejs/plugin-react": "^4.2.1",
+    "eslint": "^8.56.0",
+    "eslint-plugin-react": "^7.33.2",
+    "eslint-plugin-react-hooks": "^4.6.0",
+    "eslint-plugin-react-refresh": "^0.4.5",
+    "vite": "^5.1.0"
+  }
+}

--- a/demo/job-board/client/src/App.jsx
+++ b/demo/job-board/client/src/App.jsx
@@ -1,0 +1,19 @@
+import { Routes, Route } from 'react-router-dom'
+import Layout from './components/Layout'
+import JobListPage from './pages/JobListPage'
+import JobDetailPage from './pages/JobDetailPage'
+import NotFoundPage from './pages/NotFoundPage'
+
+function App() {
+  return (
+    <Routes>
+      <Route element={<Layout />}>
+        <Route path="/" element={<JobListPage />} />
+        <Route path="/jobs/:id" element={<JobDetailPage />} />
+        <Route path="*" element={<NotFoundPage />} />
+      </Route>
+    </Routes>
+  )
+}
+
+export default App

--- a/demo/job-board/client/src/components/Layout.css
+++ b/demo/job-board/client/src/components/Layout.css
@@ -1,0 +1,105 @@
+/* ============================================================
+   Layout component
+   ============================================================ */
+
+.layout {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+/* ---- Header ---- */
+
+.header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  height: var(--header-height);
+  background-color: var(--color-surface);
+  border-bottom: var(--border-width) solid var(--color-border);
+  box-shadow: var(--shadow-sm);
+}
+
+.header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 100%;
+}
+
+.header__brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--color-text);
+  font-weight: var(--font-bold);
+  font-size: var(--text-xl);
+  text-decoration: none;
+}
+
+.header__brand:hover {
+  text-decoration: none;
+  color: var(--color-primary);
+}
+
+.header__logo {
+  flex-shrink: 0;
+}
+
+.header__title {
+  letter-spacing: -0.01em;
+}
+
+.header__nav {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+}
+
+.header__nav-link {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.header__nav-link:hover {
+  color: var(--color-primary);
+  background-color: var(--color-primary-light);
+  text-decoration: none;
+}
+
+.header__nav-link--active {
+  color: var(--color-primary);
+  background-color: var(--color-primary-light);
+}
+
+/* ---- Main content ---- */
+
+.main {
+  flex: 1;
+  padding-top: var(--space-8);
+  padding-bottom: var(--space-16);
+}
+
+/* ---- Footer ---- */
+
+.footer {
+  border-top: var(--border-width) solid var(--color-border);
+  background-color: var(--color-surface);
+  padding: var(--space-6) 0;
+}
+
+.footer__inner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.footer__copy {
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+}

--- a/demo/job-board/client/src/components/Layout.jsx
+++ b/demo/job-board/client/src/components/Layout.jsx
@@ -1,0 +1,57 @@
+import { Outlet, NavLink } from 'react-router-dom'
+import './Layout.css'
+
+function Layout() {
+  return (
+    <div className="layout">
+      <header className="header">
+        <div className="container header__inner">
+          <NavLink to="/" className="header__brand">
+            <svg
+              className="header__logo"
+              width="28"
+              height="28"
+              viewBox="0 0 28 28"
+              fill="none"
+              aria-hidden="true"
+            >
+              <rect width="28" height="28" rx="6" fill="var(--color-primary)" />
+              <rect x="7" y="8" width="14" height="2.5" rx="1.25" fill="white" />
+              <rect x="7" y="12.75" width="10" height="2.5" rx="1.25" fill="white" />
+              <rect x="7" y="17.5" width="12" height="2.5" rx="1.25" fill="white" />
+            </svg>
+            <span className="header__title">JobBoard</span>
+          </NavLink>
+
+          <nav className="header__nav" aria-label="Main navigation">
+            <NavLink
+              to="/"
+              className={({ isActive }) =>
+                ['header__nav-link', isActive ? 'header__nav-link--active' : ''].join(' ').trim()
+              }
+              end
+            >
+              Jobs
+            </NavLink>
+          </nav>
+        </div>
+      </header>
+
+      <main className="main">
+        <div className="container">
+          <Outlet />
+        </div>
+      </main>
+
+      <footer className="footer">
+        <div className="container footer__inner">
+          <p className="footer__copy">
+            &copy; {new Date().getFullYear()} JobBoard. All rights reserved.
+          </p>
+        </div>
+      </footer>
+    </div>
+  )
+}
+
+export default Layout

--- a/demo/job-board/client/src/main.jsx
+++ b/demo/job-board/client/src/main.jsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
+import App from './App'
+import './styles/variables.css'
+import './styles/global.css'
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>,
+)

--- a/demo/job-board/client/src/pages/JobDetailPage.jsx
+++ b/demo/job-board/client/src/pages/JobDetailPage.jsx
@@ -1,0 +1,18 @@
+import { useParams } from 'react-router-dom'
+
+function JobDetailPage() {
+  const { id } = useParams()
+
+  return (
+    <div>
+      <h1 style={{ fontSize: 'var(--text-3xl)', marginBottom: 'var(--space-4)' }}>
+        Job #{id}
+      </h1>
+      <p style={{ color: 'var(--color-text-secondary)' }}>
+        Job details will appear here.
+      </p>
+    </div>
+  )
+}
+
+export default JobDetailPage

--- a/demo/job-board/client/src/pages/JobListPage.jsx
+++ b/demo/job-board/client/src/pages/JobListPage.jsx
@@ -1,0 +1,14 @@
+function JobListPage() {
+  return (
+    <div>
+      <h1 style={{ fontSize: 'var(--text-3xl)', marginBottom: 'var(--space-4)' }}>
+        Browse Jobs
+      </h1>
+      <p style={{ color: 'var(--color-text-secondary)' }}>
+        Job listings will appear here.
+      </p>
+    </div>
+  )
+}
+
+export default JobListPage

--- a/demo/job-board/client/src/pages/NotFoundPage.jsx
+++ b/demo/job-board/client/src/pages/NotFoundPage.jsx
@@ -1,0 +1,19 @@
+import { Link } from 'react-router-dom'
+
+function NotFoundPage() {
+  return (
+    <div style={{ textAlign: 'center', paddingTop: 'var(--space-16)' }}>
+      <h1 style={{ fontSize: 'var(--text-3xl)', marginBottom: 'var(--space-4)' }}>
+        404 — Page Not Found
+      </h1>
+      <p style={{ color: 'var(--color-text-secondary)', marginBottom: 'var(--space-6)' }}>
+        The page you are looking for does not exist.
+      </p>
+      <Link to="/" className="btn btn-primary">
+        Back to Jobs
+      </Link>
+    </div>
+  )
+}
+
+export default NotFoundPage

--- a/demo/job-board/client/src/styles/global.css
+++ b/demo/job-board/client/src/styles/global.css
@@ -1,0 +1,114 @@
+/* ============================================================
+   Global styles — JobBoard
+   ============================================================ */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  font-size: 16px;
+  scroll-behavior: smooth;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  line-height: var(--leading-normal);
+  color: var(--color-text);
+  background-color: var(--color-bg);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+a:hover {
+  text-decoration: underline;
+}
+
+img,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+button {
+  cursor: pointer;
+  font-family: inherit;
+}
+
+h1, h2, h3, h4, h5, h6 {
+  line-height: var(--leading-tight);
+  font-weight: var(--font-semibold);
+}
+
+/* ---- Utility classes ---- */
+
+.container {
+  width: 100%;
+  max-width: var(--max-width);
+  margin-inline: auto;
+  padding-inline: var(--space-6);
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-4);
+  border: var(--border-width) solid transparent;
+  border-radius: var(--radius-md);
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  line-height: var(--leading-normal);
+  transition: background-color var(--transition-fast), color var(--transition-fast),
+    border-color var(--transition-fast), box-shadow var(--transition-fast);
+  text-decoration: none;
+}
+
+.btn:hover {
+  text-decoration: none;
+}
+
+.btn-primary {
+  background-color: var(--color-primary);
+  color: #fff;
+  border-color: var(--color-primary);
+}
+
+.btn-primary:hover {
+  background-color: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
+}
+
+.btn-outline {
+  background-color: transparent;
+  color: var(--color-primary);
+  border-color: var(--color-primary);
+}
+
+.btn-outline:hover {
+  background-color: var(--color-primary-light);
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  padding: var(--space-1) var(--space-2);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+}
+
+.badge-primary {
+  background-color: var(--color-primary-light);
+  color: var(--color-primary-dark);
+}

--- a/demo/job-board/client/src/styles/variables.css
+++ b/demo/job-board/client/src/styles/variables.css
@@ -1,0 +1,80 @@
+/* ============================================================
+   CSS Design System — JobBoard
+   ============================================================ */
+
+:root {
+  /* ---- Colors ---- */
+  --color-primary: #2563eb;        /* blue-600 */
+  --color-primary-dark: #1d4ed8;   /* blue-700 */
+  --color-primary-light: #dbeafe;  /* blue-100 */
+
+  --color-accent: #7c3aed;         /* violet-600 */
+
+  --color-success: #16a34a;        /* green-600 */
+  --color-warning: #d97706;        /* amber-600 */
+  --color-danger: #dc2626;         /* red-600 */
+
+  --color-bg: #f8fafc;             /* slate-50 */
+  --color-surface: #ffffff;
+  --color-border: #e2e8f0;         /* slate-200 */
+
+  --color-text: #0f172a;           /* slate-900 */
+  --color-text-secondary: #475569; /* slate-600 */
+  --color-text-muted: #94a3b8;     /* slate-400 */
+
+  /* ---- Typography ---- */
+  --font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, 'Cascadia Code', 'Source Code Pro', monospace;
+
+  --text-xs:   0.75rem;   /* 12px */
+  --text-sm:   0.875rem;  /* 14px */
+  --text-base: 1rem;      /* 16px */
+  --text-lg:   1.125rem;  /* 18px */
+  --text-xl:   1.25rem;   /* 20px */
+  --text-2xl:  1.5rem;    /* 24px */
+  --text-3xl:  1.875rem;  /* 30px */
+
+  --font-normal:   400;
+  --font-medium:   500;
+  --font-semibold: 600;
+  --font-bold:     700;
+
+  --leading-tight:  1.25;
+  --leading-normal: 1.5;
+  --leading-relaxed: 1.625;
+
+  /* ---- Spacing ---- */
+  --space-1:  0.25rem;   /* 4px  */
+  --space-2:  0.5rem;    /* 8px  */
+  --space-3:  0.75rem;   /* 12px */
+  --space-4:  1rem;      /* 16px */
+  --space-5:  1.25rem;   /* 20px */
+  --space-6:  1.5rem;    /* 24px */
+  --space-8:  2rem;      /* 32px */
+  --space-10: 2.5rem;    /* 40px */
+  --space-12: 3rem;      /* 48px */
+  --space-16: 4rem;      /* 64px */
+
+  /* ---- Borders & Radii ---- */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
+  --radius-full: 9999px;
+
+  --border-width: 1px;
+
+  /* ---- Shadows ---- */
+  --shadow-sm: 0 1px 2px 0 rgb(0 0 0 / 0.05);
+  --shadow-md: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+
+  /* ---- Layout ---- */
+  --max-width: 1200px;
+  --header-height: 64px;
+
+  /* ---- Transitions ---- */
+  --transition-fast: 150ms ease;
+  --transition-base: 200ms ease;
+  --transition-slow: 300ms ease;
+}

--- a/demo/job-board/client/vite.config.js
+++ b/demo/job-board/client/vite.config.js
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+      },
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- Scaffolds the React + Vite frontend in `demo/job-board/client/`
- `index.html`, `main.jsx`, `App.jsx` wired up with React Router v6 (`BrowserRouter` + `Routes`)
- CSS design system (`src/styles/variables.css`) with CSS custom properties for colors, typography, and spacing
- `vite.config.js` configured with `/api` proxy pointing to `localhost:3001`
- Reusable `Layout` component with sticky `JobBoard` header, nav links, and footer
- Placeholder pages: `JobListPage`, `JobDetailPage`, `NotFoundPage`

Closes #3

## Test plan

- [ ] `npm install && npm run dev` starts the Vite dev server on port 5173
- [ ] Navigating to `/` renders the Layout header with 'JobBoard' branding and 'Jobs' nav link
- [ ] Navigating to `/jobs/123` renders the JobDetailPage with the ID in params
- [ ] Navigating to an unknown route renders the 404 page
- [ ] Requests to `/api/*` are proxied to `localhost:3001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)