### PR TITLE
feat: job listings page with search and filters (closes #6)

### DIFF
--- a/demo/job-board/client/src/App.jsx
+++ b/demo/job-board/client/src/App.jsx
@@ -1,6 +1,6 @@
 import { Routes, Route } from 'react-router-dom'
 import Layout from './components/Layout'
-import JobListPage from './pages/JobListPage'
+import JobListings from './pages/JobListings'
 import JobDetailPage from './pages/JobDetailPage'
 import NotFoundPage from './pages/NotFoundPage'
 
@@ -8,7 +8,7 @@ function App() {
   return (
     <Routes>
       <Route element={<Layout />}>
-        <Route path="/" element={<JobListPage />} />
+        <Route path="/" element={<JobListings />} />
         <Route path="/jobs/:id" element={<JobDetailPage />} />
         <Route path="*" element={<NotFoundPage />} />
       </Route>

--- a/demo/job-board/client/src/components/FilterBar.css
+++ b/demo/job-board/client/src/components/FilterBar.css
@@ -1,0 +1,92 @@
+.filter-bar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.filter-bar__group {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.filter-bar__label {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+.filter-bar__chips {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+
+.filter-bar__chip {
+  padding: var(--space-1) var(--space-3);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  background-color: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+  white-space: nowrap;
+}
+
+.filter-bar__chip:hover {
+  border-color: var(--color-primary);
+  color: var(--color-primary);
+}
+
+.filter-bar__chip--active {
+  background-color: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.filter-bar__chip--active:hover {
+  background-color: var(--color-primary-dark);
+  border-color: var(--color-primary-dark);
+  color: #fff;
+}
+
+.filter-bar__select {
+  padding: var(--space-1) var(--space-3);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  background-color: var(--color-surface);
+  color: var(--color-text);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  cursor: pointer;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.filter-bar__select:focus {
+  border-color: var(--color-primary);
+}
+
+.filter-bar__clear-all {
+  margin-left: auto;
+  padding: var(--space-1) var(--space-3);
+  border: none;
+  background: none;
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+  font-family: inherit;
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  text-decoration: underline;
+  transition: opacity var(--transition-fast);
+}
+
+.filter-bar__clear-all:hover {
+  opacity: 0.75;
+}

--- a/demo/job-board/client/src/components/FilterBar.jsx
+++ b/demo/job-board/client/src/components/FilterBar.jsx
@@ -1,0 +1,110 @@
+import './FilterBar.css'
+
+const JOB_TYPES = [
+  { value: 'full-time', label: 'Full-time' },
+  { value: 'part-time', label: 'Part-time' },
+  { value: 'contract', label: 'Contract' },
+  { value: 'internship', label: 'Internship' },
+]
+
+function FilterBar({ filters, onChange, locations = [] }) {
+  function toggle(key, value) {
+    if (key === 'type') {
+      const next = filters.type === value ? '' : value
+      onChange({ ...filters, type: next })
+    } else if (key === 'remote') {
+      onChange({ ...filters, remote: filters.remote === value ? '' : value })
+    } else {
+      onChange({ ...filters, [key]: value })
+    }
+  }
+
+  const hasActiveFilters =
+    filters.type || filters.remote || filters.location
+
+  return (
+    <div className="filter-bar">
+      <div className="filter-bar__group">
+        <span className="filter-bar__label">Type</span>
+        <div className="filter-bar__chips">
+          {JOB_TYPES.map((t) => (
+            <button
+              key={t.value}
+              type="button"
+              className={[
+                'filter-bar__chip',
+                filters.type === t.value ? 'filter-bar__chip--active' : '',
+              ]
+                .join(' ')
+                .trim()}
+              onClick={() => toggle('type', t.value)}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div className="filter-bar__group">
+        <span className="filter-bar__label">Remote</span>
+        <div className="filter-bar__chips">
+          <button
+            type="button"
+            className={[
+              'filter-bar__chip',
+              filters.remote === 'true' ? 'filter-bar__chip--active' : '',
+            ]
+              .join(' ')
+              .trim()}
+            onClick={() => toggle('remote', 'true')}
+          >
+            Remote
+          </button>
+          <button
+            type="button"
+            className={[
+              'filter-bar__chip',
+              filters.remote === 'false' ? 'filter-bar__chip--active' : '',
+            ]
+              .join(' ')
+              .trim()}
+            onClick={() => toggle('remote', 'false')}
+          >
+            On-site
+          </button>
+        </div>
+      </div>
+
+      {locations.length > 0 && (
+        <div className="filter-bar__group">
+          <span className="filter-bar__label">Location</span>
+          <select
+            className="filter-bar__select"
+            value={filters.location}
+            onChange={(e) => onChange({ ...filters, location: e.target.value })}
+            aria-label="Filter by location"
+          >
+            <option value="">All locations</option>
+            {locations.map((loc) => (
+              <option key={loc} value={loc}>
+                {loc}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {hasActiveFilters && (
+        <button
+          type="button"
+          className="filter-bar__clear-all"
+          onClick={() => onChange({ type: '', remote: '', location: '' })}
+        >
+          Clear filters
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default FilterBar

--- a/demo/job-board/client/src/components/JobCard.css
+++ b/demo/job-board/client/src/components/JobCard.css
@@ -1,0 +1,127 @@
+.job-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-sm);
+  transition: box-shadow var(--transition-base), border-color var(--transition-base),
+    transform var(--transition-base);
+}
+
+.job-card:hover {
+  box-shadow: var(--shadow-md);
+  border-color: var(--color-primary);
+  transform: translateY(-2px);
+}
+
+/* Header */
+.job-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.job-card__logo {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  object-fit: contain;
+  flex-shrink: 0;
+}
+
+.job-card__logo--placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: var(--color-primary-light);
+  color: var(--color-primary-dark);
+  font-size: var(--text-sm);
+  font-weight: var(--font-bold);
+  letter-spacing: 0.05em;
+}
+
+.job-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.job-card__company {
+  font-size: var(--text-sm);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.job-card__date {
+  font-size: var(--text-xs);
+  color: var(--color-text-muted);
+}
+
+/* Title */
+.job-card__title {
+  font-size: var(--text-lg);
+  font-weight: var(--font-semibold);
+  line-height: var(--leading-tight);
+}
+
+.job-card__title-link {
+  color: var(--color-text);
+  transition: color var(--transition-fast);
+}
+
+.job-card__title-link:hover {
+  color: var(--color-primary);
+  text-decoration: none;
+}
+
+/* Details row */
+.job-card__details {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.job-card__detail {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+}
+
+.job-card__detail svg {
+  flex-shrink: 0;
+  color: var(--color-text-muted);
+}
+
+/* Tags */
+.job-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-1);
+}
+
+.job-card__tag {
+  padding: var(--space-1) var(--space-2);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--text-xs);
+  font-weight: var(--font-medium);
+  color: var(--color-text-secondary);
+  background-color: var(--color-bg);
+  white-space: nowrap;
+}
+
+.job-card__tag--remote {
+  border-color: var(--color-success);
+  color: var(--color-success);
+  background-color: #f0fdf4;
+}

--- a/demo/job-board/client/src/components/JobCard.jsx
+++ b/demo/job-board/client/src/components/JobCard.jsx
@@ -1,0 +1,103 @@
+import { Link } from 'react-router-dom'
+import './JobCard.css'
+
+const TYPE_LABELS = {
+  'full-time': 'Full-time',
+  'part-time': 'Part-time',
+  contract: 'Contract',
+  internship: 'Internship',
+}
+
+function formatSalary(min, max) {
+  if (!min && !max) return null
+  const fmt = (n) =>
+    n >= 1000 ? `$${Math.round(n / 1000)}k` : `$${n}`
+  if (min && max) return `${fmt(min)} – ${fmt(max)}`
+  if (min) return `From ${fmt(min)}`
+  return `Up to ${fmt(max)}`
+}
+
+function timeAgo(dateStr) {
+  const diff = Date.now() - new Date(dateStr).getTime()
+  const days = Math.floor(diff / 86400000)
+  if (days === 0) return 'Today'
+  if (days === 1) return 'Yesterday'
+  if (days < 30) return `${days}d ago`
+  const months = Math.floor(days / 30)
+  return `${months}mo ago`
+}
+
+function CompanyLogo({ name, logoUrl }) {
+  if (logoUrl) {
+    return <img src={logoUrl} alt={name} className="job-card__logo" />
+  }
+  const initials = name
+    .split(' ')
+    .slice(0, 2)
+    .map((w) => w[0])
+    .join('')
+    .toUpperCase()
+  return (
+    <div className="job-card__logo job-card__logo--placeholder" aria-hidden="true">
+      {initials}
+    </div>
+  )
+}
+
+function JobCard({ job }) {
+  const salary = formatSalary(job.salary_min, job.salary_max)
+
+  return (
+    <article className="job-card">
+      <div className="job-card__header">
+        <CompanyLogo name={job.company_name} logoUrl={job.company_logo} />
+        <div className="job-card__meta">
+          <span className="job-card__company">{job.company_name}</span>
+          {job.created_at && (
+            <span className="job-card__date">{timeAgo(job.created_at)}</span>
+          )}
+        </div>
+      </div>
+
+      <h2 className="job-card__title">
+        <Link to={`/jobs/${job.id}`} className="job-card__title-link">
+          {job.title}
+        </Link>
+      </h2>
+
+      <div className="job-card__details">
+        {job.location && (
+          <span className="job-card__detail">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M21 10c0 7-9 13-9 13s-9-6-9-13a9 9 0 0 1 18 0z" />
+              <circle cx="12" cy="10" r="3" />
+            </svg>
+            {job.location}
+          </span>
+        )}
+        {salary && (
+          <span className="job-card__detail">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <line x1="12" y1="1" x2="12" y2="23" />
+              <path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6" />
+            </svg>
+            {salary}
+          </span>
+        )}
+      </div>
+
+      <div className="job-card__tags">
+        {job.type && (
+          <span className="job-card__tag">
+            {TYPE_LABELS[job.type] ?? job.type}
+          </span>
+        )}
+        {job.remote === 1 || job.remote === true ? (
+          <span className="job-card__tag job-card__tag--remote">Remote</span>
+        ) : null}
+      </div>
+    </article>
+  )
+}
+
+export default JobCard

--- a/demo/job-board/client/src/components/SearchBar.css
+++ b/demo/job-board/client/src/components/SearchBar.css
@@ -1,0 +1,63 @@
+.search-bar {
+  position: relative;
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.search-bar__icon {
+  position: absolute;
+  left: var(--space-3);
+  color: var(--color-text-muted);
+  pointer-events: none;
+  flex-shrink: 0;
+}
+
+.search-bar__input {
+  width: 100%;
+  padding: var(--space-3) var(--space-10) var(--space-3) calc(var(--space-3) + 18px + var(--space-2));
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-lg);
+  font-size: var(--text-base);
+  font-family: inherit;
+  color: var(--color-text);
+  background-color: var(--color-surface);
+  transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+  outline: none;
+}
+
+.search-bar__input::placeholder {
+  color: var(--color-text-muted);
+}
+
+.search-bar__input:focus {
+  border-color: var(--color-primary);
+  box-shadow: 0 0 0 3px var(--color-primary-light);
+}
+
+/* Hide browser-native clear button */
+.search-bar__input::-webkit-search-cancel-button {
+  -webkit-appearance: none;
+}
+
+.search-bar__clear {
+  position: absolute;
+  right: var(--space-3);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border: none;
+  border-radius: var(--radius-full);
+  background-color: var(--color-text-muted);
+  color: white;
+  font-size: 14px;
+  line-height: 1;
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.search-bar__clear:hover {
+  background-color: var(--color-text-secondary);
+}

--- a/demo/job-board/client/src/components/SearchBar.jsx
+++ b/demo/job-board/client/src/components/SearchBar.jsx
@@ -1,0 +1,43 @@
+import './SearchBar.css'
+
+function SearchBar({ value, onChange, placeholder = 'Search jobs by title or keyword…' }) {
+  return (
+    <div className="search-bar">
+      <svg
+        className="search-bar__icon"
+        width="18"
+        height="18"
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        aria-hidden="true"
+      >
+        <circle cx="11" cy="11" r="8" />
+        <line x1="21" y1="21" x2="16.65" y2="16.65" />
+      </svg>
+      <input
+        type="search"
+        className="search-bar__input"
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        placeholder={placeholder}
+        aria-label="Search jobs"
+      />
+      {value && (
+        <button
+          className="search-bar__clear"
+          onClick={() => onChange('')}
+          aria-label="Clear search"
+          type="button"
+        >
+          ×
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default SearchBar

--- a/demo/job-board/client/src/pages/JobListings.css
+++ b/demo/job-board/client/src/pages/JobListings.css
@@ -1,0 +1,160 @@
+/* ============================================================
+   Job Listings Page
+   ============================================================ */
+
+.job-listings {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+  padding-block: var(--space-8);
+}
+
+/* Hero / search section */
+.job-listings__hero {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  text-align: center;
+  max-width: 640px;
+  margin-inline: auto;
+  width: 100%;
+}
+
+.job-listings__heading {
+  font-size: var(--text-3xl);
+  font-weight: var(--font-bold);
+  color: var(--color-text);
+}
+
+.job-listings__subheading {
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  margin-top: calc(-1 * var(--space-2));
+}
+
+/* Toolbar row */
+.job-listings__toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4) var(--space-6);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+}
+
+.job-listings__count {
+  margin-left: auto;
+  font-size: var(--text-sm);
+  color: var(--color-text-muted);
+  white-space: nowrap;
+}
+
+/* Job grid */
+.job-listings__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(320px, 1fr));
+  gap: var(--space-4);
+}
+
+/* Error state */
+.job-listings__error {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-4) var(--space-6);
+  background-color: #fef2f2;
+  border: var(--border-width) solid #fecaca;
+  border-radius: var(--radius-lg);
+  color: var(--color-danger);
+  font-size: var(--text-sm);
+}
+
+/* Empty state */
+.job-listings__empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-16) var(--space-6);
+  text-align: center;
+  color: var(--color-text-muted);
+}
+
+.job-listings__empty p {
+  font-size: var(--text-lg);
+}
+
+/* ============================================================
+   Skeleton loading cards
+   ============================================================ */
+
+@keyframes shimmer {
+  0% { background-position: -400px 0; }
+  100% { background-position: 400px 0; }
+}
+
+.skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--color-border) 25%,
+    #f1f5f9 50%,
+    var(--color-border) 75%
+  );
+  background-size: 800px 100%;
+  animation: shimmer 1.4s infinite linear;
+  border-radius: var(--radius-sm);
+}
+
+.skeleton--logo {
+  width: 44px;
+  height: 44px;
+  border-radius: var(--radius-md);
+  flex-shrink: 0;
+}
+
+.skeleton--text {
+  height: 14px;
+  border-radius: var(--radius-sm);
+}
+
+.skeleton--text-xs { width: 80px; }
+.skeleton--text-sm { width: 120px; }
+.skeleton--text-md { width: 200px; }
+.skeleton--text-lg { width: 75%; height: 20px; }
+
+.skeleton--tag {
+  width: 70px;
+  height: 22px;
+  border-radius: var(--radius-full);
+}
+
+.skeleton-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  padding: var(--space-6);
+  background-color: var(--color-surface);
+  border: var(--border-width) solid var(--color-border);
+  border-radius: var(--radius-xl);
+}
+
+.skeleton-card__header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.skeleton-card__meta {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  flex: 1;
+}
+
+.skeleton-card__tags {
+  display: flex;
+  gap: var(--space-2);
+}

--- a/demo/job-board/client/src/pages/JobListings.jsx
+++ b/demo/job-board/client/src/pages/JobListings.jsx
@@ -1,0 +1,166 @@
+import { useState, useEffect, useCallback, useMemo } from 'react'
+import SearchBar from '../components/SearchBar'
+import FilterBar from '../components/FilterBar'
+import JobCard from '../components/JobCard'
+import './JobListings.css'
+
+function useDebounce(value, delay = 350) {
+  const [debounced, setDebounced] = useState(value)
+  useEffect(() => {
+    const id = setTimeout(() => setDebounced(value), delay)
+    return () => clearTimeout(id)
+  }, [value, delay])
+  return debounced
+}
+
+function SkeletonCard() {
+  return (
+    <div className="skeleton-card" aria-hidden="true">
+      <div className="skeleton-card__header">
+        <div className="skeleton skeleton--logo" />
+        <div className="skeleton-card__meta">
+          <div className="skeleton skeleton--text skeleton--text-sm" />
+          <div className="skeleton skeleton--text skeleton--text-xs" />
+        </div>
+      </div>
+      <div className="skeleton skeleton--text skeleton--text-lg" />
+      <div className="skeleton skeleton--text skeleton--text-md" />
+      <div className="skeleton-card__tags">
+        <div className="skeleton skeleton--tag" />
+        <div className="skeleton skeleton--tag" />
+      </div>
+    </div>
+  )
+}
+
+function JobListings() {
+  const [allJobs, setAllJobs] = useState([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState(null)
+
+  const [search, setSearch] = useState('')
+  const [filters, setFilters] = useState({ type: '', remote: '', location: '' })
+
+  const debouncedSearch = useDebounce(search)
+  const debouncedLocation = useDebounce(filters.location)
+
+  const fetchJobs = useCallback(async (params) => {
+    setLoading(true)
+    setError(null)
+    try {
+      const query = new URLSearchParams()
+      if (params.search) query.set('search', params.search)
+      if (params.location) query.set('location', params.location)
+      if (params.remote !== '') query.set('remote', params.remote)
+      query.set('status', 'open')
+
+      const res = await fetch(`/api/jobs?${query}`)
+      if (!res.ok) throw new Error(`Server error: ${res.status}`)
+      const data = await res.json()
+      setAllJobs(data)
+    } catch (err) {
+      setError(err.message)
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchJobs({
+      search: debouncedSearch,
+      location: debouncedLocation,
+      remote: filters.remote,
+    })
+  }, [debouncedSearch, debouncedLocation, filters.remote, fetchJobs])
+
+  // Client-side type filter (API doesn't expose type param)
+  const jobs = useMemo(() => {
+    if (!filters.type) return allJobs
+    return allJobs.filter((j) => j.type === filters.type)
+  }, [allJobs, filters.type])
+
+  // Derive unique locations from loaded jobs for dropdown
+  const locations = useMemo(() => {
+    const locs = [...new Set(allJobs.map((j) => j.location).filter(Boolean))].sort()
+    return locs
+  }, [allJobs])
+
+  return (
+    <div className="job-listings">
+      <div className="job-listings__hero">
+        <h1 className="job-listings__heading">Find your next opportunity</h1>
+        <p className="job-listings__subheading">
+          Browse open roles from top companies
+        </p>
+        <SearchBar value={search} onChange={setSearch} />
+      </div>
+
+      <div className="job-listings__toolbar">
+        <FilterBar
+          filters={filters}
+          onChange={setFilters}
+          locations={locations}
+        />
+        {!loading && !error && (
+          <span className="job-listings__count">
+            {jobs.length} {jobs.length === 1 ? 'job' : 'jobs'} found
+          </span>
+        )}
+      </div>
+
+      {error && (
+        <div className="job-listings__error" role="alert">
+          <strong>Failed to load jobs.</strong> {error}
+          <button
+            type="button"
+            className="btn btn-outline"
+            style={{ marginLeft: 'var(--space-4)' }}
+            onClick={() =>
+              fetchJobs({
+                search: debouncedSearch,
+                location: debouncedLocation,
+                remote: filters.remote,
+              })
+            }
+          >
+            Retry
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="job-listings__grid" aria-busy="true" aria-label="Loading jobs">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <SkeletonCard key={i} />
+          ))}
+        </div>
+      ) : !error && jobs.length === 0 ? (
+        <div className="job-listings__empty">
+          <svg width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+            <circle cx="11" cy="11" r="8" />
+            <line x1="21" y1="21" x2="16.65" y2="16.65" />
+          </svg>
+          <p>No jobs match your search.</p>
+          <button
+            type="button"
+            className="btn btn-outline"
+            onClick={() => {
+              setSearch('')
+              setFilters({ type: '', remote: '', location: '' })
+            }}
+          >
+            Clear all filters
+          </button>
+        </div>
+      ) : (
+        <div className="job-listings__grid">
+          {jobs.map((job) => (
+            <JobCard key={job.id} job={job} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default JobListings


### PR DESCRIPTION
## Summary

- **JobListings.jsx** — full page with hero search bar, filter toolbar, and responsive card grid
- **SearchBar** — controlled text input with debounce (350ms), clear button, focus ring
- **FilterBar** — job type chips (Full-time / Part-time / Contract / Internship), Remote/On-site toggle, location dropdown populated dynamically from loaded jobs; "Clear filters" link when any filter is active
- **JobCard** — company logo placeholder (initials fallback), title link, location + salary detail row, remote badge and type chip; hover lift animation
- Loading state: 6 shimmer skeleton cards with CSS animation while fetching
- Error state: inline banner with retry button
- Empty state: icon + message + "Clear all filters" button
- Wires to `GET /api/jobs` with `search`, `location`, `remote`, and `status=open` query params; job-type filtering done client-side

## Test plan

- [ ] Start the API server (`npm run dev:server`) and the Vite dev server (`npm run dev` in `client/`)
- [ ] Visit `/` — should show loading skeletons then a grid of job cards
- [ ] Type in the search bar — results should filter after a short debounce
- [ ] Toggle Remote / On-site chips — grid should update
- [ ] Select a job type chip — client-side filter applied on top of API results
- [ ] Pick a location from the dropdown — API request includes the location param
- [ ] Click "Clear filters" — all filters reset and full list reloads
- [ ] Click a job card title — should navigate to `/jobs/:id`
- [ ] Simulate API down — error banner with Retry button should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)